### PR TITLE
Create Release Tag Conditional

### DIFF
--- a/.github/workflows/Tag-Branch-Release.yml
+++ b/.github/workflows/Tag-Branch-Release.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Get variables
         run: |
             echo ${{ github.event.release.target_commitish }}
-            echo ${{ github.repository.default_branch }}
+            echo ${{ github.event.repository.default_branch }}
 
   Deploy-To-Production:
     runs-on: ubuntu-latest
     needs: [Build, Deploy-To-Staging]
-    if: ${{ github.event.release.target_commitish == github.repository.default_branch }}
+    if: ${{ github.event.release.target_commitish == github.event.repository.default_branch }}
     environment:
       name: Production
     steps:

--- a/.github/workflows/Tag-Branch-Release.yml
+++ b/.github/workflows/Tag-Branch-Release.yml
@@ -7,37 +7,21 @@ on:
 jobs:
   Build: 
     runs-on: ubuntu-latest
-#    outputs:
-#      targetBranch: ${{ steps.get-release-branch.outputs.targetBranch }}
-#      defaultBranch: ${{ steps.get-release-branch.outputs.defaultBranch }}
     steps:
-#      - uses: actions/checkout@v3
-
-#      - name: Check target branch of release
-#        id: get-release-branch
-#        run: |
-#          targetBranch=$(gh release view $tag --json targetCommitish -q .[])
-#          defaultBranch=$(gh repo view --json defaultBranchRef -q .[].name)
-#          echo "The default branch of the repository is $defaultBranch"
-#          echo "The target branch of the release is $targetBranch"
-#          echo "targetBranch=$targetBranch" >> "$GITHUB_OUTPUT"
-#          echo "defaultBranch=$defaultBranch" >> "$GITHUB_OUTPUT"
-          
-
       - name: Build
         run: |
           # Build Commands
           echo "Building app..."
-
   Deploy-To-Staging:
     runs-on: ubuntu-latest
     needs: [Build]
-    if: 
     environment:
       name: Staging
     steps:
-      - name: Get Event
-        run: cat $GITHUB_EVENT_PATH
+      - name: Get variables
+        run: |
+            echo ${{ github.event.release.target_commitish }}
+            echo ${{ github.repository.default_branch }}
 
   Deploy-To-Production:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow file `.github/workflows/Tag-Branch-Release.yml` to streamline the build and deployment process. The changes focus on removing commented-out code and simplifying the steps for retrieving branch information.

### Workflow Simplification:

* Removed commented-out code related to checking out the repository and determining the target and default branches. (`.github/workflows/Tag-Branch-Release.yml`)
* Simplified the `Deploy-To-Staging` job by replacing the step that retrieves the event with a step that echoes the target commitish and default branch. (`.github/workflows/Tag-Branch-Release.yml`)
* Fixed the condition in the `Deploy-To-Production` job to correctly compare the target commitish with the default branch. (`.github/workflows/Tag-Branch-Release.yml`)